### PR TITLE
Add Brand logo and Model picture

### DIFF
--- a/teemip-network-mgmt-extended/datamodel.teemip-network-mgmt-extended.xml
+++ b/teemip-network-mgmt-extended/datamodel.teemip-network-mgmt-extended.xml
@@ -1181,7 +1181,19 @@
       </presentation>
     </class>
     <class id="Model" _delta="must_exist">
+      <properties>
+        <fields_semantic>
+          <image_attribute _delta="define_if_not_exists">picture</image_attribute>
+        </fields_semantic>
+      </properties>
       <fields>
+        <field id="picture" xsi:type="AttributeImage" _delta="define_if_not_exists">
+          <display_max_width>256</display_max_width>
+          <display_max_height>256</display_max_height>
+          <storage_max_width>512</storage_max_width>
+          <storage_max_height>512</storage_max_height>
+          <is_null_allowed>true</is_null_allowed>
+        </field>
         <field id="type" xsi:type="AttributeEnum" _delta="must_exist">
           <values _delta="must_exist">
             <value id="NetworkDeviceComponent" _delta="define">
@@ -1190,6 +1202,15 @@
           </values>
         </field>
       </fields>
+      <presentation>
+        <details>
+          <items>
+            <item id="picture" _delta="define_if_not_exists">
+              <rank>30</rank>
+            </item>
+          </items>
+        </details>
+      </presentation>
     </class>
     <class id="AggregateLink" _delta="define">
       <parent>NetworkInterface</parent>
@@ -2504,6 +2525,38 @@
         </relation>
       </relations>
     </class>
+    <class id="Brand" _created_in="itop-config-mgmt" _delta="must_exist">
+      <properties>
+        <fields_semantic>
+          <image_attribute _delta="define_if_not_exists">logo</image_attribute>
+        </fields_semantic>
+      </properties>
+      <fields>
+        <field id="logo" xsi:type="AttributeImage" _delta="define_if_not_exists">
+          <display_max_width>96</display_max_width>
+          <display_max_height>96</display_max_height>
+          <storage_max_width>128</storage_max_width>
+          <storage_max_height>128</storage_max_height>
+          <is_null_allowed>true</is_null_allowed>
+        </field>
+      </fields>
+      <presentation>
+        <details>
+          <items>
+            <item id="logo" _delta="define_if_not_exists">
+              <rank>20</rank>
+            </item>
+          </items>
+        </details>
+        <summary _delta="define_if_not_exists">
+          <items>
+            <item id="name">
+              <rank>10</rank>
+            </item>
+          </items>
+        </summary>
+      </presentation>
+    </class>
   </classes>
   <menus>
     <menu id="ConfigManagementOverview" xsi:type="DashboardMenuNode" _delta="must_exist">
@@ -2628,4 +2681,12 @@
       </profile>
     </profiles>
   </user_rights>
+  <dictionaries>
+    <dictionary id="EN US">
+      <entries>
+        <entry id="Class:Brand/Attribute:logo" _delta="define_if_not_exists">Logo</entry>
+        <entry id="Class:Model/Attribute:picture" _delta="define_if_not_exists">Picture</entry>
+      </entries>
+    </dictionary>
+  </dictionaries>
 </itop_design>

--- a/teemip-network-mgmt-extended/datamodel.teemip-network-mgmt-extended.xml
+++ b/teemip-network-mgmt-extended/datamodel.teemip-network-mgmt-extended.xml
@@ -1210,6 +1210,13 @@
             </item>
           </items>
         </details>
+        <summary>
+          <items>
+            <item id="picture" _delta="define_if_not_exists">
+              <rank>30</rank>
+            </item>
+          </items>
+        </summary>
       </presentation>
     </class>
     <class id="AggregateLink" _delta="define">


### PR DESCRIPTION
## Objective

Some people (including me) like it to also document the brand logo of their devices. It would also be nice to have a picture of a specific model for easier recognition.

## Proposed solution

* Added a new logo `AttributeImage` field to the class `Brand` and use that also as `image_attribute`:

![Screenshot of a Brand object having the logo](https://github.com/Combodo/iTop/assets/228588/a3684670-fc64-4a15-b743-89317c56f5cf)

![Screenshot of a Server creation form selecting the Brand](https://github.com/Combodo/iTop/assets/228588/124cf1b1-39f8-433a-84e8-f2f50b6a88a7)

* Added a new picture `AttributeImage` field to the class `Model` and use that also as `image_attribute`:

![Screenshot of a Model object having a picture and mouseover on the brand link](https://github.com/Combodo/iTop/assets/228588/2d3b5027-4055-48f3-8c57-1ee5d4433bed)

* Also created a new summary card for `Brand` to be able to see the logo when hovering on a brand link, as seen in previous screenshot.
