### PR TITLE
fix(AggregateLink): Align naming with PhysicalInterface naming

### DIFF
--- a/teemip-network-mgmt-extended/dictionaries/en.dict.teemip-network-mgmt-extended.php
+++ b/teemip-network-mgmt-extended/dictionaries/en.dict.teemip-network-mgmt-extended.php
@@ -200,6 +200,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:AggregateLink' => 'Aggregate Link',
 	'Class:AggregateLink+' => 'Combine multiple network connections in parallel',
 	'Class:AggregateLink:peerinfo' => 'Peer Information',
+	'Class:AggregateLink/Name' => '%2$s %1$s',
 	'Class:AggregateLink/Attribute:macaddress' => 'MAC address',
 	'Class:AggregateLink/Attribute:macaddress+' => '',
 	'Class:AggregateLink/Attribute:layer2protocol_id' => 'Protocol',


### PR DESCRIPTION
This makes the default sorting of `NetworkInterface` more logical.