### PR TITLE
feat(InterfaceSpeed): Define logical ordering and uniqueness rule

### DIFF
--- a/teemip-network-mgmt-extended/datamodel.teemip-network-mgmt-extended.xml
+++ b/teemip-network-mgmt-extended/datamodel.teemip-network-mgmt-extended.xml
@@ -194,6 +194,11 @@
             <attribute id="name"/>
           </attributes>
         </naming>
+        <order>
+          <columns>
+            <column id="raw" ascending="true"/>
+          </columns>
+        </order>
         <reconciliation>
           <attributes>
             <attribute id="name"/>
@@ -203,6 +208,14 @@
           <rule id="name">
             <attributes>
               <attribute id="name"/>
+            </attributes>
+            <filter/>
+            <disabled>false</disabled>
+            <is_blocking>true</is_blocking>
+          </rule>
+          <rule id="raw">
+            <attributes>
+              <attribute id="raw"/>
             </attributes>
             <filter/>
             <disabled>false</disabled>


### PR DESCRIPTION
It is more logical to sort `InterfaceSpeed` items by raw value than alphabetically on the name.

Also added uniqueness rule to only allow 1 item with the same raw value.